### PR TITLE
Fix Style/HashSyntax: Omit the hash value cases

### DIFF
--- a/changelog/fix_false_positive_on_hash_syntax_value_omission.md
+++ b/changelog/fix_false_positive_on_hash_syntax_value_omission.md
@@ -1,0 +1,1 @@
+* [#10357](https://github.com/rubocop/rubocop/pull/10357): Fix a false positive for `Style/HashSyntax` when omitting the value. ([@berkos][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -46,10 +46,22 @@ module RuboCop
 
       def without_parentheses_call_expr_follows?(node)
         return false unless (ancestor = node.parent.parent)
-        return false unless (right_sibling = ancestor.right_sibling)
 
-        ancestor.respond_to?(:parenthesized?) && !ancestor.parenthesized? &&
-          right_sibling.respond_to?(:parenthesized?) && !right_sibling.parenthesized?
+        right_sibling = ancestor.right_sibling
+
+        return true if right_sibling.nil? && without_parentheses?(ancestor)
+        return false unless right_sibling
+        return true if node_with_block_and_arguments?(right_sibling)
+
+        without_parentheses?(ancestor) && without_parentheses?(right_sibling)
+      end
+
+      def without_parentheses?(node)
+        node.respond_to?(:parenthesized?) && !node.parenthesized?
+      end
+
+      def node_with_block_and_arguments?(node)
+        node.respond_to?(:block_type?) && node.block_type? && node.children&.first&.arguments?
       end
     end
   end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -819,7 +819,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'does not register an offense when hash valuees are omitted' do
+      it 'does not register an offense when hash values are omitted' do
         expect_no_offenses(<<~RUBY)
           {foo:, bar:}
         RUBY
@@ -891,7 +891,39 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'registers an offense when with parentheses call expr follows' do
+      it 'does not register an offense when one line condition follows' do
+        expect_no_offenses(<<~RUBY)
+          foo value: value if bar
+        RUBY
+      end
+
+      it 'does not register an offense when call expr with argument and a block follows' do
+        expect_no_offenses(<<~RUBY)
+          foo value: value
+          foo arg do
+            value
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when call expr without arguments and with a block follows' do
+        expect_offense(<<~RUBY)
+          foo value: value
+                     ^^^^^ Omit the hash value.
+          bar do
+            value
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo value:
+          bar do
+            value
+          end
+        RUBY
+      end
+
+      it 'registers and corrects an offense when with parentheses call expr follows' do
         expect_offense(<<~RUBY)
           foo value: value
                      ^^^^^ Omit the hash value.


### PR DESCRIPTION
### Summary

There are certain cases that suggestion of Style/HashSyntax: Omit the hash value and then the autocorrect will produce invalid syntaxt

This change acts conservative and does not change/suggest change for those cases

Example:

RSpec.shared_examples 'Examples' do |option_a:|
  include_examples 'Example A', option_a: option_a if option_a # Omitting the option_a value would produce invalid syntax

  include_examples 'Example B', option_a: option_a # Omitting the option_a value would produce invalid syntax

  describe '.describe' do
    it { true }
  end

  include_examples 'Example C', option_a: option_a # Valid omission
end

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
